### PR TITLE
test: add truncated era1 file for typed tx testing

### DIFF
--- a/portal-bridge/src/types/era1.rs
+++ b/portal-bridge/src/types/era1.rs
@@ -21,7 +21,8 @@ use std::{
 // Accumulator        = { type: 0x07,   data: hash_tree_root(List(HeaderRecord, 8192)) }
 // BlockIndex         = { type: 0x3266, data: block-index }
 
-const ERA1_ENTRY_COUNT: usize = 8192 * 4 + 3;
+const BLOCK_TUPLE_COUNT: usize = 8192;
+const ERA1_ENTRY_COUNT: usize = BLOCK_TUPLE_COUNT * 4 + 3;
 
 pub struct Era1 {
     pub version: VersionEntry,
@@ -44,7 +45,7 @@ impl Era1 {
         );
         let version = VersionEntry::try_from(&file.entries[0])?;
         let mut block_tuples = vec![];
-        for count in 0..8192 {
+        for count in 0..BLOCK_TUPLE_COUNT {
             let mut entries: [Entry; 4] = Default::default();
             for (i, entry) in entries.iter_mut().enumerate() {
                 *entry = file.entries[count * 4 + i + 1].clone();
@@ -438,6 +439,12 @@ mod tests {
     #[case::era1("../test_assets/era1/mainnet-00001-a5364e9a.era1")]
     // epoch #10 contains txs
     #[case::era1("../test_assets/era1/mainnet-00010-5f5d4516.era1")]
+    // this is a test era1 file that has been amended for size purposes,
+    // since era1 files that contain typed txs are quite large.
+    // it was created by copying the `mainnet-01600-c6a9ee35.era1` file
+    // - the first 10 block tuples are included, unchanged
+    // - the following 8182 block tuples contain empty bodies and receipts
+    #[case::era1("../test_assets/era1/test-mainnet-01600-xxxxxxxx.era1")]
     fn test_era1(#[case] path: &str) {
         let era1 = Era1::read_from_file(path.to_string()).unwrap();
         let actual = era1.write().unwrap();


### PR DESCRIPTION
### What was wrong?
Imo we should have a test to cover the changes in this pr. The normal era1 files that contain typed txs are very large, and running this test takes quite a while, so I created a truncated version of an era1 file with only 10 full block tuples, to test against.

I also ran the test against the complete, original era1 file, and it passed successfully, although it took a good 10-15 mins.

### How was it fixed?
- created truncated test asset

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
